### PR TITLE
Make need_fullpath = false

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 DEBUG = 0
 FRONTEND_SUPPORTS_RGB565 = 1
+LOAD_FROM_MEMORY = 1
 
 CORE_DIR := .
 
@@ -524,6 +525,10 @@ endif
 
 ifeq ($(NO_GCC),1)
    WARNINGS :=
+endif
+
+ifeq ($(LOAD_FROM_MEMORY),1)
+   FLAGS := -DLOAD_FROM_MEMORY
 endif
 
 ifeq ($(DEBUG), 1)


### PR DESCRIPTION
Fixes https://github.com/libretro/beetle-ngp-libretro/issues/41

fullpath support can be set false or true quickly by compiling with LOAD_FROM_MEMORY=0 (makes need_fullpath = true for platforms that does not work with it false.)

need_fullpath = false  is set by default.