### PR TITLE
upstream bugfix

### DIFF
--- a/mednafen/ngp/TLCS-900h/TLCS900h_registers.c
+++ b/mednafen/ngp/TLCS-900h/TLCS900h_registers.c
@@ -962,6 +962,9 @@ void reset_registers(void)
 
 	rErr = RERR_VALUE;
 
+	gpr[0] = 0xff23c3;
+	gpr[1] = 0xff23df;
+	gpr[2] = 0x006480;
 	REGXSP = 0x00006C00; //Confirmed from BIOS, 
 						//immediately changes value from default of 0x100
 }

--- a/mednafen/ngp/mem.cpp
+++ b/mednafen/ngp/mem.cpp
@@ -609,4 +609,20 @@ void reset_memory(void)
 	storeB(0x8402, 0x80);	// Flash cycle = 1.3s
 
 	storeB(0x87E2, loadB(0x6F95) ? 0x00 : 0x80);
+
+	//
+	// Metal Slug - 2nd Mission oddly relies on a specific character RAM pattern.
+	//
+	{
+	 static const uint8 char_data[64] = {
+	 	255, 63, 255, 255, 0, 252, 255, 255, 255, 63, 3, 0, 255, 255, 255, 255, 
+	 	240, 243, 252, 243, 255, 3, 255, 195, 255, 243, 243, 243, 240, 243, 240, 195, 
+		207, 15, 207, 15, 207, 15, 207, 207, 207, 255, 207, 255, 207, 255, 207, 63, 
+		255, 192, 252, 195, 240, 207, 192, 255, 192, 255, 240, 207, 252, 195, 255, 192 };
+
+         for(i = 0; i < 64; i++)
+	 {
+	  storeB(0xA1C0 + i, char_data[i]);
+	 }
+	}
 }

--- a/mednafen/ngp/rom.cpp
+++ b/mednafen/ngp/rom.cpp
@@ -53,39 +53,6 @@ static void rom_hack(void)
       /* "Dokodemo Mahjong (J)" */
       ngpc_rom.data[0x23] = 0x00;	// Fix rom header
    }
-
-   if (MATCH_CATALOG(65, 5))
-   {
-      /* "Puyo Pop (V05) (JUE)" */
-      int i;
-      for (i = 0x8F0; i < 0x8FC; i++)
-         ngpc_rom.data[i] = 0;
-   }
-
-   if (MATCH_CATALOG(65, 6))
-   {
-      /* "Puyo Pop (V06) (JUE)" */
-      int i;
-      for (i = 0x8F0; i < 0x8FC; i++)
-         ngpc_rom.data[i] = 0;
-   }
-
-   if (MATCH_CATALOG(97, 4))
-   {
-      /*
-       * "Metal Slug - 2nd Mission (JUE) [!]"
-       * "Metal Slug - 2nd Mission (JUE) [h1]"
-       *
-       * Enable dev-kit code path, because otherwise it doesn't
-       * allow jumping or firing (for some reason!)
-       */
-
-      ngpc_rom.data[0x1f] = 0xFF;
-
-      /* Enables in-game voices ("Pineapple", etc.)
-       * that were aren't supposed to be available in Dev-kit mode. */
-      ngpc_rom.data[0x8DDF8] = 0xF0;	//28DDF7: "RET NZ" -> "RET F"
-   }
 }
 
 static void rom_display_header(void)


### PR DESCRIPTION
Initialize XIX, XIY, and XIZ to match what the BIOS leaves them as(as observed via MESS' debugger), and removed the ROM patches/hacks for "Puyo Pop".

Initialize VRAM differently to partially reflect the state the BIOS leaves it in, and removed the "Metal Slug - 2nd Mission" ROM patch/hack (thanks to "FluBBa" for the tip on what the game was doing/relied on).