### PR TITLE
Change name to Beetle NeoPop, add .npc extension

### DIFF
--- a/libretro.cpp
+++ b/libretro.cpp
@@ -400,9 +400,9 @@ static void set_basename(const char *path)
 }
 
 #define MEDNAFEN_CORE_NAME_MODULE "ngp"
-#define MEDNAFEN_CORE_NAME "Mednafen NeoPop"
+#define MEDNAFEN_CORE_NAME "Beetle NeoPop"
 #define MEDNAFEN_CORE_VERSION "v0.9.36.1"
-#define MEDNAFEN_CORE_EXTENSIONS "ngp|ngc|ngpc"
+#define MEDNAFEN_CORE_EXTENSIONS "ngp|ngc|ngpc|npc"
 #define MEDNAFEN_CORE_TIMING_FPS 60.25
 #define MEDNAFEN_CORE_GEOMETRY_BASE_W 160 
 #define MEDNAFEN_CORE_GEOMETRY_BASE_H 152


### PR DESCRIPTION
- Change name from Mednafen NeoPop to Beetle NeoPop similar to other beetle cores and keeps it in sync with core's info file
- add .npc as supported file extensions - mednafen standalone has this as one of the supported extensions (might just be similar to existing no-intro supported file extensions.