### PR TITLE
Fix compiler error due to missing assert.h include

### DIFF
--- a/mednafen/ngp/interrupt.cpp
+++ b/mednafen/ngp/interrupt.cpp
@@ -25,6 +25,10 @@
 #include "dma.h"
 #include "system.h"
 
+#ifndef NDEBUG
+#include <assert.h>
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif


### PR DESCRIPTION
While building the core, I got the following error:

```
mednafen/ngp/interrupt.cpp: In function ‘void set_interrupt(uint8_t, bool)’:
mednafen/ngp/interrupt.cpp:73:4: error: ‘assert’ was not declared in this scope
    assert(index < 24);
    ^~~~~~
```

On inspection, the file calls `assert()`, but the `assert.h` header is not included. This PR adds the missing include.

After applying the patch, the core builds and loads successfully.