### PR TITLE
Mingw: Use backslash for includes

### DIFF
--- a/mednafen/mempatcher.cpp
+++ b/mednafen/mempatcher.cpp
@@ -26,7 +26,7 @@
 #include "mempatcher.h"
 
 #ifdef _WIN32
-#include "compat\msvc.h"
+#include "compat/msvc.h"
 #endif
 
 static uint8 **RAMPtrs = NULL;


### PR DESCRIPTION
Forward slash is breaking mingw cross compiles.